### PR TITLE
Basic changes required for Typo.js works in other places than in Chrome extension

### DIFF
--- a/typo/typo.js
+++ b/typo/typo.js
@@ -19,9 +19,11 @@
  * @returns {Typo} A Typo object.
  */
 
-var Typo = function (dictionary, affData, wordsData) {
+var Typo = function (dictionary, affData, wordsData, settings) {
+	settings = settings || {};
+
 	/** Determines the method used for auto-loading .aff and .dic files. **/
-	this.platform = "chrome";
+	this.platform = settings.platform || "chrome";
 
 	this.dictionary = null;
 
@@ -33,7 +35,7 @@ var Typo = function (dictionary, affData, wordsData) {
 
 	this.replacementTable = [];
 
-	this.flags = {};
+	this.flags = settings.flags || {};
 
 	if (dictionary) {
 		this.dictionary = dictionary;
@@ -41,6 +43,10 @@ var Typo = function (dictionary, affData, wordsData) {
 		if (this.platform == "chrome") {
 			if (!affData) affData = this._readFile(chrome.extension.getURL("lib/typo/dictionaries/" + dictionary + "/" + dictionary + ".aff"));
 			if (!wordsData) wordsData = this._readFile(chrome.extension.getURL("lib/typo/dictionaries/" + dictionary + "/" + dictionary + ".dic"));
+		} else {
+			var path = settings.dictionaryPath || '';
+			if (!affData) affData = this._readFile(path + "/" + dictionary + "/" + dictionary + ".aff");
+			if (!wordsData) wordsData = this._readFile(path + "/" + dictionary + "/" + dictionary + ".dic");
 		}
 
 		this.rules = this._parseAFF(affData);


### PR DESCRIPTION
Hi,

I found that there is no way to get around `this.platform = "chrome";` nor add flags I wanted, so I fork your work and made some minimal changes. This should not break any current code rely on Typo.js.

If you agree with this approach, I will push my next change as another pull request here:

https://github.com/timdream/Typo.js/tree/no-edit-distance-2-suggest

The particular application I am working on requires these to work. 
