### PR TITLE
IE Bug

### DIFF
--- a/typo/typo.js
+++ b/typo/typo.js
@@ -147,7 +147,10 @@ Typo.prototype = {
 		
 		var req = new XMLHttpRequest();
 		req.open("GET", path, false);
-		req.overrideMimeType("text/plain; charset=" + charset);
+		
+		if (req.overrideMimeType)
+			req.overrideMimeType("text/plain; charset=" + charset);
+		
 		req.send(null);
 		
 		return req.responseText;


### PR DESCRIPTION
Currently Typo.js is broken in IE because IE does not support overrideMimeType, so I just added a simple check that it exists.
