### PR TITLE
suggest() uses web workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ var is_spelled_correctly = dictionary.check("mispelled");
 To get suggested corrections for a misspelled word, do this:
 	
 ```javascript
-var array_of_suggestions = dictionary.suggest("mispeling");
+dictionary.suggest("mispeling", function(array_of_suggestions){// do something here});
 
 // array_of_suggestions == ["misspelling", "dispelling", "misdealing", "misfiling", "misruling"]
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ var is_spelled_correctly = dictionary.check("mispelled");
 To get suggested corrections for a misspelled word, do this:
 	
 ```javascript
-dictionary.suggest("mispeling", function(array_of_suggestions){// do something here});
+dictionary.suggest("mispeling", function(array_of_suggestions){/* do something here */});
 
 // array_of_suggestions == ["misspelling", "dispelling", "misdealing", "misfiling", "misruling"]
 ```

--- a/tests/english.js
+++ b/tests/english.js
@@ -132,11 +132,28 @@ function testDictionary(dict) {
 	});
 	
 	asyncTest("Replacement rules are implemented", function () {
-		dict.suggest("wagh", 5, function(suggestions){deepEqual(suggestions, [ "weigh" ]); });
-		dict.suggest("ceit", 5, function(suggestions){deepEqual(suggestions, [ "cat" ]); });
-		dict.suggest("seau", 5, function(suggestions){deepEqual(suggestions, [ "so" ]); });
-		dict.suggest("shaccable", 5, function(suggestions){deepEqual(suggestions, [ "shakable" ]); });
-		dict.suggest("soker", 5, function(suggestions){deepEqual(suggestions, [ "choker" ]); start(); });
+		var testCount = 0;
+			
+		dict.suggest("wagh", 5, function(suggestions){
+			deepEqual(suggestions, [ "weigh" ]); 
+			if (++testCount == 5) start(); 
+		});
+		dict.suggest("ceit", 5, function(suggestions){
+			deepEqual(suggestions, [ "cat" ]); 
+			if (++testCount == 5) start(); 
+		});
+		dict.suggest("seau", 5, function(suggestions){
+			deepEqual(suggestions, [ "so" ]); 
+			if (++testCount == 5) start(); 
+		});
+		dict.suggest("shaccable", 5, function(suggestions){
+			deepEqual(suggestions, [ "shakable" ]); 
+			if (++testCount == 5) start(); 
+		});
+		dict.suggest("soker", 5, function(suggestions){
+			deepEqual(suggestions, [ "choker" ]); 
+			if (++testCount == 5) start(); 
+		});
 	});
 	
 	test("Contractions", function () {

--- a/tests/english.js
+++ b/tests/english.js
@@ -13,9 +13,19 @@ function testDictionary(dict) {
 		equal(dict.dictionary, "en_US");
 	});
 	
-	test("Suggestions", function () {
-		deepEqual(dict.suggest("speling"), [ "spelling", "spieling", "spewing", "selling", "peeling" ]);
-		deepEqual(dict.suggest("spitting"), [ ], "Correctly spelled words receive no suggestions.");
+	asyncTest("Suggestions", function () {
+		var testCount = 0;
+			
+		dict.suggest("spitting", 5, function(suggestions){ 
+			deepEqual(suggestions, [ ], "Correctly spelled words receive no suggestions."); 
+			if (++testCount == 2) start();
+		});
+		
+		dict.suggest("speling", 5, function(suggestions){ 
+			deepEqual(suggestions, [ "spelling", "spieling", "spewing", "selling", "peeling" ]);
+			if (++testCount == 2) start();
+		});
+
 	});
 	
 	test("Correct checking of words with no affixes", function () {
@@ -121,12 +131,12 @@ function testDictionary(dict) {
 		equal(dict.check("acceptability's's"), false);
 	});
 	
-	test("Replacement rules are implemented", function () {
-		deepEqual(dict.suggest("wagh"), [ "weigh" ]);
-		deepEqual(dict.suggest("ceit"), [ "cat" ]);
-		deepEqual(dict.suggest("seau"), [ "so" ]);
-		deepEqual(dict.suggest("shaccable"), [ "shakable" ]);
-		deepEqual(dict.suggest("soker"), [ "choker" ]);
+	asyncTest("Replacement rules are implemented", function () {
+		dict.suggest("wagh", 5, function(suggestions){deepEqual(suggestions, [ "weigh" ]); });
+		dict.suggest("ceit", 5, function(suggestions){deepEqual(suggestions, [ "cat" ]); });
+		dict.suggest("seau", 5, function(suggestions){deepEqual(suggestions, [ "so" ]); });
+		dict.suggest("shaccable", 5, function(suggestions){deepEqual(suggestions, [ "shakable" ]); });
+		dict.suggest("soker", 5, function(suggestions){deepEqual(suggestions, [ "choker" ]); start(); });
 	});
 	
 	test("Contractions", function () {

--- a/tests/wordprocessor.js
+++ b/tests/wordprocessor.js
@@ -1,0 +1,67 @@
+self.addEventListener('message', function(e) { 
+	var words = e.data;
+	
+	var rv = [];
+	var alphabet = "abcdefghijklmnopqrstuvwxyz";
+	
+	for (var ii = 0, _iilen = words.length; ii < _iilen; ii++) {
+		var word = words[ii];
+		
+		var splits = [];
+	
+		for (var i = 0, _len = word.length + 1; i < _len; i++) {
+			splits.push([ word.substring(0, i), word.substring(i, word.length) ]);
+		}
+	
+		var deletes = [];
+	
+		for (var i = 0, _len = splits.length; i < _len; i++) {
+			var s = splits[i];
+		
+			if (s[1]) {
+				deletes.push(s[0] + s[1].substring(1));
+			}
+		}
+	
+		var transposes = [];
+	
+		for (var i = 0, _len = splits.length; i < _len; i++) {
+			var s = splits[i];
+		
+			if (s[1].length > 1) {
+				transposes.push(s[0] + s[1][1] + s[1][0] + s[1].substring(2));
+			}
+		}
+	
+		var replaces = [];
+	
+		for (var i = 0, _len = splits.length; i < _len; i++) {
+			var s = splits[i];
+		
+			if (s[1]) {
+				for (var j = 0, _jlen = alphabet.length; j < _jlen; j++) {
+					replaces.push(s[0] + alphabet[j] + s[1].substring(1));
+				}
+			}
+		}
+	
+		var inserts = [];
+	
+		for (var i = 0, _len = splits.length; i < _len; i++) {
+			var s = splits[i];
+		
+			if (s[1]) {
+				for (var j = 0, _jlen = alphabet.length; j < _jlen; j++) {
+					inserts.push(s[0] + alphabet[j] + s[1]);
+				}
+			}
+		}
+				
+		rv = rv.concat(inserts);
+		rv = rv.concat(deletes);
+		rv = rv.concat(transposes);
+		rv = rv.concat(replaces);
+	}
+	
+	postMessage(rv);
+});

--- a/typo/typo.js
+++ b/typo/typo.js
@@ -599,7 +599,10 @@ Typo.prototype = {
 	suggest : function (word, limit, callback) {
 		if (!limit) limit = 5;
 		
-		if (this.check(word)) callback([]);
+		if (this.check(word)) {
+			callback([]);
+			return;
+		}
 		
 		// Check the replacement table.
 		for (var i = 0, _len = this.replacementTable.length; i < _len; i++) {

--- a/typo/typo.js
+++ b/typo/typo.js
@@ -599,7 +599,7 @@ Typo.prototype = {
 	suggest : function (word, limit, callback) {
 		if (!limit) limit = 5;
 		
-		if (this.check(word)) return [];
+		if (this.check(word)) callback([]);
 		
 		// Check the replacement table.
 		for (var i = 0, _len = this.replacementTable.length; i < _len; i++) {

--- a/typo/typo.js
+++ b/typo/typo.js
@@ -596,7 +596,7 @@ Typo.prototype = {
 	
 	alphabet : "",
 	
-	suggest : function (word, limit) {
+	suggest : function (word, limit, callback) {
 		if (!limit) limit = 5;
 		
 		if (this.check(word)) return [];
@@ -638,69 +638,45 @@ Typo.prototype = {
 		}
 		*/
 		
-		function edits1(words) {
+		function edits1(words, callback) {
+			var numWorkers = 4;
+			
 			var rv = [];
 			
-			for (var ii = 0, _iilen = words.length; ii < _iilen; ii++) {
-				var word = words[ii];
-				
-				var splits = [];
+			var workers = [];
+			var workersCompleted = [];
 			
-				for (var i = 0, _len = word.length + 1; i < _len; i++) {
-					splits.push([ word.substring(0, i), word.substring(i, word.length) ]);
-				}
-			
-				var deletes = [];
-			
-				for (var i = 0, _len = splits.length; i < _len; i++) {
-					var s = splits[i];
-				
-					if (s[1]) {
-						deletes.push(s[0] + s[1].substring(1));
-					}
-				}
-			
-				var transposes = [];
-			
-				for (var i = 0, _len = splits.length; i < _len; i++) {
-					var s = splits[i];
-				
-					if (s[1].length > 1) {
-						transposes.push(s[0] + s[1][1] + s[1][0] + s[1].substring(2));
-					}
-				}
-			
-				var replaces = [];
-			
-				for (var i = 0, _len = splits.length; i < _len; i++) {
-					var s = splits[i];
-				
-					if (s[1]) {
-						for (var j = 0, _jlen = self.alphabet.length; j < _jlen; j++) {
-							replaces.push(s[0] + self.alphabet[j] + s[1].substring(1));
-						}
-					}
-				}
-			
-				var inserts = [];
-			
-				for (var i = 0, _len = splits.length; i < _len; i++) {
-					var s = splits[i];
-				
-					if (s[1]) {
-						for (var j = 0, _jlen = self.alphabet.length; j < _jlen; j++) {
-							replaces.push(s[0] + self.alphabet[j] + s[1]);
-						}
-					}
-				}
-			
-				rv = rv.concat(deletes);
-				rv = rv.concat(transposes);
-				rv = rv.concat(replaces);
-				rv = rv.concat(inserts);
+			var processNext = function() {
+				for (var i = 0; i < numWorkers; ++i) {
+					if (!workersCompleted[i]) {
+						return;
+			  	  	}			  	  			  
+			  	}
+			  	callback(rv);
 			}
 			
-			return rv;
+			for (var i = 0; i < numWorkers; ++i) {
+				var worker = new Worker("wordprocessor.js");
+				worker.addEventListener('message', function(index) {
+					return function(e) {
+					  rv = rv.concat(e.data);
+					  workersCompleted[index] = true;
+					  processNext();
+					};
+				}(i));
+				
+				workers.push(worker); 	
+				workersCompleted.push(false);
+			}
+			
+			var sliceSize = words.length / numWorkers;
+			for (var i = 0; i < numWorkers; ++i) {
+				if (i != numWorkers - 1) {
+					workers[i].postMessage(words.slice(sliceSize * i, sliceSize * (i+1)));
+				} else {
+					workers[i].postMessage(words.slice(sliceSize * i));
+				}
+			}					
 		}
 		
 		function known(words) {
@@ -715,52 +691,57 @@ Typo.prototype = {
 			return rv;
 		}
 		
-		function correct(word) {
+		function correct(word, callback) {
 			// Get the edit-distance-1 and edit-distance-2 forms of this word.
-			var ed1 = edits1([word]);
-			var ed2 = edits1(ed1);
+			edits1([word], function(ed1) {
+				edits1(ed1,function(ed2) {
 			
-			var corrections = known(ed1).concat(known(ed2));
+					var corrections = known(ed1).concat(known(ed2));
+					
+					// Sort the edits based on how many different ways they were created.
+					var weighted_corrections = {};
+					
+					for (var i = 0, _len = corrections.length; i < _len; i++) {
+						if (!(corrections[i] in weighted_corrections)) {
+							weighted_corrections[corrections[i]] = 1;
+						}
+						else {
+							weighted_corrections[corrections[i]] += 1;
+						}
+					}
+					
+					var sorted_corrections = [];
+					
+					for (var i in weighted_corrections) {
+						sorted_corrections.push([ i, weighted_corrections[i] ]);
+					}
+					
+					function sorter(a, b) {
+						if (a[1] < b[1]) {
+							return -1;
+						}
+						
+						return 1;
+					}
+					
+					sorted_corrections.sort(sorter).reverse();
+					
+					var rv = [];
+					
+					for (var i = 0, _len = Math.min(limit, sorted_corrections.length); i < _len; i++) {
+						if (!self.hasFlag(sorted_corrections[i][0], "NOSUGGEST")) {
+							rv.push(sorted_corrections[i][0]);
+						}
+					}
+					
+					callback(rv);		
+				});
+			});
 			
-			// Sort the edits based on how many different ways they were created.
-			var weighted_corrections = {};
-			
-			for (var i = 0, _len = corrections.length; i < _len; i++) {
-				if (!(corrections[i] in weighted_corrections)) {
-					weighted_corrections[corrections[i]] = 1;
-				}
-				else {
-					weighted_corrections[corrections[i]] += 1;
-				}
-			}
-			
-			var sorted_corrections = [];
-			
-			for (var i in weighted_corrections) {
-				sorted_corrections.push([ i, weighted_corrections[i] ]);
-			}
-			
-			function sorter(a, b) {
-				if (a[1] < b[1]) {
-					return -1;
-				}
-				
-				return 1;
-			}
-			
-			sorted_corrections.sort(sorter).reverse();
-			
-			var rv = [];
-			
-			for (var i = 0, _len = Math.min(limit, sorted_corrections.length); i < _len; i++) {
-				if (!self.hasFlag(sorted_corrections[i][0], "NOSUGGEST")) {
-					rv.push(sorted_corrections[i][0]);
-				}
-			}
-			
-			return rv;
 		}
 		
-		return correct(word);
+		correct(word, function(rv) {
+			callback(rv);
+		});
 	}
 };

--- a/typo/typo.js
+++ b/typo/typo.js
@@ -612,7 +612,8 @@ Typo.prototype = {
 				var correctedWord = word.replace(replacementEntry[0], replacementEntry[1]);
 				
 				if (this.check(correctedWord)) {
-					return [ correctedWord ];
+					callback( [ correctedWord ] );
+					return;
 				}
 			}
 		}

--- a/typo/wordprocessor.js
+++ b/typo/wordprocessor.js
@@ -1,0 +1,67 @@
+self.addEventListener('message', function(e) { 
+	var words = e.data;
+	
+	var rv = [];
+	var alphabet = "abcdefghijklmnopqrstuvwxyz";
+	
+	for (var ii = 0, _iilen = words.length; ii < _iilen; ii++) {
+		var word = words[ii];
+		
+		var splits = [];
+	
+		for (var i = 0, _len = word.length + 1; i < _len; i++) {
+			splits.push([ word.substring(0, i), word.substring(i, word.length) ]);
+		}
+	
+		var deletes = [];
+	
+		for (var i = 0, _len = splits.length; i < _len; i++) {
+			var s = splits[i];
+		
+			if (s[1]) {
+				deletes.push(s[0] + s[1].substring(1));
+			}
+		}
+	
+		var transposes = [];
+	
+		for (var i = 0, _len = splits.length; i < _len; i++) {
+			var s = splits[i];
+		
+			if (s[1].length > 1) {
+				transposes.push(s[0] + s[1][1] + s[1][0] + s[1].substring(2));
+			}
+		}
+	
+		var replaces = [];
+	
+		for (var i = 0, _len = splits.length; i < _len; i++) {
+			var s = splits[i];
+		
+			if (s[1]) {
+				for (var j = 0, _jlen = alphabet.length; j < _jlen; j++) {
+					replaces.push(s[0] + alphabet[j] + s[1].substring(1));
+				}
+			}
+		}
+	
+		var inserts = [];
+	
+		for (var i = 0, _len = splits.length; i < _len; i++) {
+			var s = splits[i];
+		
+			if (s[1]) {
+				for (var j = 0, _jlen = alphabet.length; j < _jlen; j++) {
+					inserts.push(s[0] + alphabet[j] + s[1]);
+				}
+			}
+		}
+				
+		rv = rv.concat(inserts);
+		rv = rv.concat(deletes);
+		rv = rv.concat(transposes);
+		rv = rv.concat(replaces);
+	}
+	
+	postMessage(rv);
+});


### PR DESCRIPTION
I've rewritten the suggest() function to take advantage of web workers. This significantly reduces the time it takes to get suggestions for words more than about 5 characters long.

I updated the English tests, but because of the way the web workers split up their processing, deepEqual() sometimes doesn't work because the arrays can be constructed in a different order. But the theory is sound :).
