### PR TITLE
Significantly improved performance of edit1 (the key bottleneck in suggest())

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,16 @@ Typo.js is a JavaScript spellchecker that uses Hunspell-style dictionaries.  Its
 Usage
 =====
 
-To use Typo, simply include the typo.js file in your extension's background page, and then initialize the dictionary like so:
+To use Typo in an extension, simply include the typo.js file in your extension's background page, and then initialize the dictionary like so:
 
 ```javascript
 var dictionary = new Typo("en_US");
+```
+
+To use Typo in a standard web application you need to pass a settings object, explicitly setting the platform (to something other than "chrome" (the default -- which works for chrome _extensions_), and you also need to provide a path to the folder containing to desired dictionary.
+
+```javascript
+var dictionary = new Typo("en_US", false, false, {platform: "web", dictionaryPath: "typo/dictionaries"}),
 ```
 
 To check if a word is spelled correctly, do this:

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 	        position: absolute;
 	        left: 0;
 	        top: 100%;
-	        background-color: white;
+	        background-color: #ffc;
 	        box-shadow: 1px 2px 4px 0 rgba(0,0,0,0.5);
 	        display: inline-block;
 	        z-index: 1;
@@ -142,7 +142,10 @@ And the mome raths outgrabe.
         editor.on('click', '.suggestions', function(evt){
             var word = $(evt.target).closest('li').text();
             if( !$(evt.target).closest('li').is('.ignore') ){
-                $(evt.target).closest('.typo').replaceWith(document.createTextNode(word));
+                var wordNode = document.createTextNode(word);
+                // by doing this rather than using replaceWidth the caret ends up
+                // AFTER the replaced word
+                $(evt.target).closest('.typo').before(wordNode).remove();
             }
         });
     </script>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<title>Typo.js Test</title>
+	<style>
+	    span.typo {
+	        border-bottom: 2px dotted red;
+	    }
+	</style>
+</head>
+<body>
+    <div class="editor" style="border: 1px solid #ccc;" contenteditable=true spellcheck=false>
+"Jabberwocky"<br>
+<br>
+'Twas brillig, and the slithy toves<br>
+Did gyre and gimble in the wabe;<br>
+All mimsy were the borogoves,<br>
+And the mome raths outgrabe.<br>
+<br>
+"Beware the Jabberwock, my son!<br>
+The jaws that bite, the claws that catch!<br>
+Beware the Jubjub bird, and shun<br>
+The frumious Bandersnatch!"<br>
+<br>
+He took his vorpal sword in hand:<br>
+Long time the manxome foe he sought—<br>
+So rested he by the Tumtum tree,<br>
+And stood awhile in thought.<br>
+<br>
+And as in uffish thought he stood,<br>
+The Jabberwock, with eyes of flame,<br>
+Came whiffling through the tulgey wood,<br>
+And burbled as it came!<br>
+<br>
+One, two! One, two! and through and through<br>
+The vorpal blade went snicker-snack!<br>
+He left it dead, and with its head<br>
+He went galumphing back.<br>
+<br>
+"And hast thou slain the Jabberwock?<br>
+Come to my arms, my beamish boy!<br>
+O frabjous day! Callooh! Callay!"<br>
+He chortled in his joy.<br>
+<br>
+'Twas brillig, and the slithy toves<br>
+Did gyre and gimble in the wabe;<br>
+All mimsy were the borogoves,<br>
+And the mome raths outgrabe.
+    </div>
+    <button class="check">Find Typos</button>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="typo/typo.js"></script>
+    <script>
+        var dictionary = new Typo("en_US", false, false, {platform: "web", dictionaryPath: "typo/dictionaries"}),
+            check = $('.check'),
+            editor = $('.editor'),
+            textNodes = editor.contents()
+                              .filter(function(){
+                                return this.nodeType === 3;
+                              });
+            
+        check.on('click', function(){
+            $.each(textNodes, function(nodeIndex){
+                var text = $(this).text(),
+                    foundTypo = false,
+                    words = text.match(/([a-zA-Z]+|[^a-zA-Z]+)/g); // text.split(/\s+/);
+                    
+                $.each(words, function(idx){
+                    if(this.match(/[a-zA-Z]+/) && !dictionary.check(this)){
+                        words[idx] = "<span class='typo'>" + this + "</span>";
+                        foundTypo = true;
+                    } 
+                });
+                
+                if( foundTypo ){
+                    text = "<span>" + words.join('') + "</span>";
+                    $(this).replaceWith($(text));
+                }
+            });
+        });
+        
+        editor.on('click', '.typo', function(evt){
+            var typo = $(evt.target).text(),
+                start = Date.now(),
+                suggestions = dictionary.suggest( typo );
+            
+            console.log('elapsed', Date.now() - start);
+            alert( suggestions.length ? suggestions.join('\n') : 'No suggestions' );
+        });
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -71,11 +71,12 @@ And the mome raths outgrabe.
         
         clear.on('click', function(){
             $('.typo').each( function(){
-                $(this).replaceWith( $(this).text() );
+                $(this).replaceWith(document.createTextNode( $(this).text() ) );
             } );
         });
         
         check.on('click', function(){
+            clear.trigger('click');
             var textNodes = editor.textNodes();
             $.each(textNodes, function(nodeIndex){
                 var text = $(this).text(),
@@ -91,7 +92,7 @@ And the mome raths outgrabe.
                 
                 if( foundTypo ){
                     text = "<span>" + words.join('') + "</span>";
-                    $(this).replaceWith($(text));
+                    $(this).replaceWith($(text).contents());
                 }
             });
         });

--- a/index.html
+++ b/index.html
@@ -6,6 +6,30 @@
 	<style>
 	    span.typo {
 	        border-bottom: 2px dotted red;
+            position: relative;
+	    }
+	    ul.suggestions {
+	        position: absolute;
+	        left: 0;
+	        top: 100%;
+	        background-color: white;
+	        box-shadow: 1px 2px 4px 0 rgba(0,0,0,0.5);
+	        display: inline-block;
+	        z-index: 1;
+	        white-space: nowrap;
+	        margin: 0;
+	        padding: 0;
+	        list-style: none;
+	    }
+	    li.ignore {
+	        font-style: italic;
+	    }
+	    ul.suggestions li {
+	        padding: 2px 6px;
+	    }
+	    ul.suggestions li:hover {
+	        background-color: rgba(0,0,255,0.25);
+	        cursor: pointer;
 	    }
 	</style>
 </head>
@@ -100,10 +124,26 @@ And the mome raths outgrabe.
         editor.on('click', '.typo', function(evt){
             var typo = $(evt.target).text(),
                 start = Date.now(),
-                suggestions = dictionary.suggest( typo.toLowerCase() );
+                suggestions = dictionary.suggest( typo.toLowerCase() ),
+                list = $('<ul>').addClass('suggestions');
             
             console.log('elapsed', Date.now() - start);
-            alert( suggestions.length ? suggestions.join('\n') : 'No suggestions' );
+            $('.suggestions').remove();
+            if( suggestions.length ){
+                $.each(suggestions, function(){
+                    list.append( $('<li>').text(this) );
+                });
+            } else {            
+                list.append( $('<li>').addClass('ignore').text('No suggestions') );
+            }
+            list.appendTo(evt.target);
+        });
+        
+        editor.on('click', '.suggestions', function(evt){
+            var word = $(evt.target).closest('li').text();
+            if( !$(evt.target).closest('li').is('.ignore') ){
+                $(evt.target).closest('.typo').replaceWith(document.createTextNode(word));
+            }
         });
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -49,18 +49,34 @@ All mimsy were the borogoves,<br>
 And the mome raths outgrabe.
     </div>
     <button class="check">Find Typos</button>
+    <button class="clear">Clear Typos</button>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="typo/typo.js"></script>
     <script>
         var dictionary = new Typo("en_US", false, false, {platform: "web", dictionaryPath: "typo/dictionaries"}),
             check = $('.check'),
-            editor = $('.editor'),
-            textNodes = editor.contents()
-                              .filter(function(){
-                                return this.nodeType === 3;
-                              });
-            
+            clear = $('.clear'),
+            editor = $('.editor');
+        
+        function textNodesUnder(el){
+            var n, a=[], walk=document.createTreeWalker(el,NodeFilter.SHOW_TEXT,null,false);
+            while(n=walk.nextNode()) a.push(n);
+            return a;
+        }
+        
+        $.fn.textNodes = function(){
+            var list = textNodesUnder(this[0]);
+            return $(list);
+        }
+        
+        clear.on('click', function(){
+            $('.typo').each( function(){
+                $(this).replaceWith( $(this).text() );
+            } );
+        });
+        
         check.on('click', function(){
+            var textNodes = editor.textNodes();
             $.each(textNodes, function(nodeIndex){
                 var text = $(this).text(),
                     foundTypo = false,

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@ And the mome raths outgrabe.
         editor.on('click', '.typo', function(evt){
             var typo = $(evt.target).text(),
                 start = Date.now(),
-                suggestions = dictionary.suggest( typo );
+                suggestions = dictionary.suggest( typo.toLowerCase() );
             
             console.log('elapsed', Date.now() - start);
             alert( suggestions.length ? suggestions.join('\n') : 'No suggestions' );

--- a/index.html
+++ b/index.html
@@ -100,8 +100,9 @@ And the mome raths outgrabe.
         });
         
         check.on('click', function(){
+            var textNodes = editor.textNodes(),
+                start = Date.now();
             clear.trigger('click');
-            var textNodes = editor.textNodes();
             $.each(textNodes, function(nodeIndex){
                 var text = $(this).text(),
                     foundTypo = false,
@@ -119,6 +120,7 @@ And the mome raths outgrabe.
                     $(this).replaceWith($(text).contents());
                 }
             });
+            console.log("find typos", Date.now() - start);
         });
         
         editor.on('click', '.typo', function(evt){

--- a/typo/typo.js
+++ b/typo/typo.js
@@ -597,7 +597,7 @@ Typo.prototype = {
 	alphabet : "",
 	
 	suggest : function (word, limit) {
-		if (!limit) limit = 5;
+	    limit = limit || 5;
 		
 		if (this.check(word)) return [];
 		
@@ -643,61 +643,34 @@ Typo.prototype = {
 			
 			for (var ii = 0, _iilen = words.length; ii < _iilen; ii++) {
 				var word = words[ii];
-				
-				var splits = [];
 			
 				for (var i = 0, _len = word.length + 1; i < _len; i++) {
-					splits.push([ word.substring(0, i), word.substring(i, word.length) ]);
-				}
-			
-				var deletes = [];
-			
-				for (var i = 0, _len = splits.length; i < _len; i++) {
-					var s = splits[i];
-				
+					var s = [ word.substring(0, i), word.substring(i) ];
+
 					if (s[1]) {
-						deletes.push(s[0] + s[1].substring(1));
+						rv.push(s[0] + s[1].substring(1));
 					}
-				}
-			
-				var transposes = [];
-			
-				for (var i = 0, _len = splits.length; i < _len; i++) {
-					var s = splits[i];
 				
-					if (s[1].length > 1) {
-						transposes.push(s[0] + s[1][1] + s[1][0] + s[1].substring(2));
+				    // eliminate transpositions of identical letters
+					if (s[1].length > 1 && s[1][1] !== s[1][0]) {
+						rv.push(s[0] + s[1][1] + s[1][0] + s[1].substring(2));
 					}
-				}
-			
-				var replaces = [];
-			
-				for (var i = 0, _len = splits.length; i < _len; i++) {
-					var s = splits[i];
 				
 					if (s[1]) {
 						for (var j = 0, _jlen = self.alphabet.length; j < _jlen; j++) {
-							replaces.push(s[0] + self.alphabet[j] + s[1].substring(1));
+						    // eliminate replacement of a letter by itself
+						    if( self.alphabet[j] != s[1].substring(0,1) ){
+							    rv.push(s[0] + self.alphabet[j] + s[1].substring(1));
+							}
 						}
 					}
-				}
-			
-				var inserts = [];
-			
-				for (var i = 0, _len = splits.length; i < _len; i++) {
-					var s = splits[i];
 				
 					if (s[1]) {
 						for (var j = 0, _jlen = self.alphabet.length; j < _jlen; j++) {
-							replaces.push(s[0] + self.alphabet[j] + s[1]);
+							rv.push(s[0] + self.alphabet[j] + s[1]);
 						}
 					}
 				}
-			
-				rv = rv.concat(deletes);
-				rv = rv.concat(transposes);
-				rv = rv.concat(replaces);
-				rv = rv.concat(inserts);
 			}
 			
 			return rv;
@@ -760,7 +733,6 @@ Typo.prototype = {
 			
 			return rv;
 		}
-		
 		return correct(word);
 	}
 };

--- a/typo/typo.js
+++ b/typo/typo.js
@@ -697,7 +697,7 @@ Typo.prototype = {
 			// Get the edit-distance-1 and edit-distance-2 forms of this word.
 			var ed1 = edits1([word]),
 			    ed2 = edits1(ed1),
-			    corrections = known(ed1).concat(known(ed2));
+			    corrections = known(ed1.concat(ed2));
 			
 			// Sort the edits based on how many different ways they were created.
 			var weighted_corrections = {};

--- a/typo/typo.js
+++ b/typo/typo.js
@@ -437,6 +437,7 @@ Typo.prototype = {
 		for (var i = 0, _len = entries.length; i < _len; i++) {
 			var entry = entries[i];
 			
+		    // Note: regex.test() is faster for Firefox but slower for Chrome
 			if (!entry.match || word.match(entry.match)) {
 				var newWord = word;
 				
@@ -541,6 +542,7 @@ Typo.prototype = {
 			// Check if this might be a compound word.
 			if ("COMPOUNDMIN" in this.flags && word.length >= this.flags.COMPOUNDMIN) {
 				for (var i = 0, _len = this.compoundRules.length; i < _len; i++) {
+				    // Note: regex.test() is faster for Firefox but slower for Chrome
 					if (word.match(this.compoundRules[i])) {
 						return true;
 					}
@@ -599,6 +601,7 @@ Typo.prototype = {
 	    limit = limit || 5;
 	    
 		if (this.check(word)) return [];
+		
 	    if( this.memoized === undefined ){
 	        this.memoized = {};
 	    }

--- a/typo/typo.js
+++ b/typo/typo.js
@@ -34,6 +34,7 @@
  */
 
 var Typo = function (dictionary, affData, wordsData, settings) {
+  
 	settings = settings || {};
 	
 	/** Determines the method used for auto-loading .aff and .dic files. **/
@@ -88,7 +89,7 @@ var Typo = function (dictionary, affData, wordsData, settings) {
 		// Get rid of any codes from the compound rule codes that are never used 
 		// (or that were special regex characters).  Not especially necessary... 
 		for (var i in this.compoundRuleCodes) {
-			if (this.compoundRuleCodes[i].length == 0) {
+			if (this.compoundRuleCodes[i].length === 0) {
 				delete this.compoundRuleCodes[i];
 			}
 		}
@@ -388,8 +389,6 @@ Typo.prototype = {
 		// Remove comments
 		data = data.replace(/^\t.*$/mg, "");
 		
-		return data;
-		
 		// Trim each line
 		data = data.replace(/^\s\s*/m, '').replace(/\s\s*$/m, '');
 		
@@ -419,7 +418,7 @@ Typo.prototype = {
 			return flags;
 		}
 		else if (this.flags.FLAG === "num") {
-			return textCode.split(",");
+			return textCodes.split(",");
 		}
 	},
 	
@@ -598,8 +597,14 @@ Typo.prototype = {
 	
 	suggest : function (word, limit) {
 	    limit = limit || 5;
-		
+	    
 		if (this.check(word)) return [];
+	    if( this.memoized === undefined ){
+	        this.memoized = {};
+	    }
+		if( this.memoized[word] ){
+		    return this.memoized[word];
+		}
 		
 		// Check the replacement table.
 		for (var i = 0, _len = this.replacementTable.length; i < _len; i++) {
@@ -690,10 +695,9 @@ Typo.prototype = {
 		
 		function correct(word) {
 			// Get the edit-distance-1 and edit-distance-2 forms of this word.
-			var ed1 = edits1([word]);
-			var ed2 = edits1(ed1);
-			
-			var corrections = known(ed1).concat(known(ed2));
+			var ed1 = edits1([word]),
+			    ed2 = edits1(ed1),
+			    corrections = known(ed1).concat(known(ed2));
 			
 			// Sort the edits based on how many different ways they were created.
 			var weighted_corrections = {};
@@ -733,6 +737,7 @@ Typo.prototype = {
 			
 			return rv;
 		}
-		return correct(word);
+		this.memoized[word] = correct(word);
+		return this.memoized[word];
 	}
 };


### PR DESCRIPTION
I created a pathological example to play with typo.js and then tuned performance to make the generation of suggestions for longer words (e.g. bandersnatch and jabberwock) toleration (sub 1 second).