### PR TITLE
handle trailing whitespace in dictionary file.

### DIFF
--- a/typo/typo.js
+++ b/typo/typo.js
@@ -366,7 +366,7 @@ Typo.prototype = {
 				}
 			}
 			else {
-				addWord(word, []);
+				addWord(word.trim(), []);
 			}
 		}
 		


### PR DESCRIPTION
This trims whitespace from entries in a dictionary file.  It currently only trims words that don't have associated affix rules.  
