### PR TITLE
Only try to read from chrome extension if that is the environment

### DIFF
--- a/typo/typo.js
+++ b/typo/typo.js
@@ -54,7 +54,7 @@ var Typo = function (dictionary, affData, wordsData, settings) {
 	if (dictionary) {
 		this.dictionary = dictionary;
 		
-		if (this.platform == "chrome") {
+		if (window.chrome && window.chrome.extension) {
 			if (!affData) affData = this._readFile(chrome.extension.getURL("lib/typo/dictionaries/" + dictionary + "/" + dictionary + ".aff"));
 			if (!wordsData) wordsData = this._readFile(chrome.extension.getURL("lib/typo/dictionaries/" + dictionary + "/" + dictionary + ".dic"));
 		} else {


### PR DESCRIPTION
Detect whether the library is being used in a chrome extension, not whether the library is being used in chrome, so that it works on webpages in chrome.