### PR TITLE
Adding condition for window existence

### DIFF
--- a/typo/typo.js
+++ b/typo/typo.js
@@ -49,7 +49,7 @@ var Typo = function (dictionary, affData, wordsData, settings) {
 	if (dictionary) {
 		this.dictionary = dictionary;
 		
-		if ('chrome' in window && 'extension' in window.chrome && 'getURL' in window.chrome.extension) {
+		if (window && 'chrome' in window && 'extension' in window.chrome && 'getURL' in window.chrome.extension) {
 			if (!affData) affData = this._readFile(chrome.extension.getURL("lib/typo/dictionaries/" + dictionary + "/" + dictionary + ".aff"));
 			if (!wordsData) wordsData = this._readFile(chrome.extension.getURL("lib/typo/dictionaries/" + dictionary + "/" + dictionary + ".dic"));
 		} else {


### PR DESCRIPTION
If condition not present, this library crashes in Node.js and WebWorkers. I think people are likely to use this library in web workers to allow HTML form spellchecking without lagging user's UI.