### PR TITLE
Make test suite run by showing them in extension popup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,5 +2,8 @@
 	"manifest_version": 2,
 	"name": "Typo.js Testing Harness",
 	"version": "1.0",
-	"description": "Load tests/index.html in the browser to run the test suite."
+	"description": "Load tests/index.html in the browser to run the test suite.",
+	"browser_action": {
+		"default_popup": "tests/index.html"
+	}
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "Typo.js Testing Harness",
-	"version": "1.0",
+	"version": "1.1",
 	"description": "Load tests/index.html in the browser to run the test suite.",
 	"browser_action": {
 		"default_popup": "tests/index.html"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,4 @@
 These tests can be run by loading the entire Typo.js project as a Chrome 
-extension and then loading the tests/index.html file in the browser. A
-manifest.json file is included in the project root to make this as easy
+extension and then clicking the Typo.js Testing Harness icon in the browser.
+A manifest.json file is included in the project root to make this as easy
 as possible.

--- a/tests/english.html
+++ b/tests/english.html
@@ -3,6 +3,7 @@
 		<meta charset="ISO8859-1">
 		<title>Typo.js English Test Suite</title>
 		<link rel="stylesheet" href="lib/qunit.css" type="text/css" media="screen" />
+		<link rel="stylesheet" href="tests.css" type="text/css" media="screen" />
 		<script type="text/javascript" src="lib/jquery-1.9.1.js"></script>
 		<script type="text/javascript" src="lib/qunit.js"></script>
 		<script type="text/javascript" src="../typo/typo.js"></script>

--- a/tests/french.html
+++ b/tests/french.html
@@ -3,6 +3,7 @@
 		<meta charset="UTF-8">
 		<title>Typo.js French Test Suite</title>
 		<link rel="stylesheet" href="lib/qunit.css" type="text/css" media="screen" />
+		<link rel="stylesheet" href="tests.css" type="text/css" media="screen" />
 		<script type="text/javascript" src="lib/jquery-1.9.1.js"></script>
 		<script type="text/javascript" src="lib/qunit.js"></script>
 		<script type="text/javascript" src="../typo/typo.js"></script>

--- a/tests/general.html
+++ b/tests/general.html
@@ -3,6 +3,7 @@
 		<meta charset="ISO8859-1">
 		<title>Typo.js General Test Suite</title>
 		<link rel="stylesheet" href="lib/qunit.css" type="text/css" media="screen" />
+		<link rel="stylesheet" href="tests.css" type="text/css" media="screen" />
 		<script type="text/javascript" src="lib/jquery-1.9.1.js"></script>
 		<script type="text/javascript" src="lib/qunit.js"></script>
 		<script type="text/javascript" src="../typo/typo.js"></script>

--- a/tests/german.html
+++ b/tests/german.html
@@ -3,6 +3,7 @@
 		<meta charset="ISO8859-1">
 		<title>Typo.js German Test Suite</title>
 		<link rel="stylesheet" href="lib/qunit.css" type="text/css" media="screen" />
+		<link rel="stylesheet" href="tests.css" type="text/css" media="screen" />
 		<script type="text/javascript" src="lib/jquery-1.9.1.js"></script>
 		<script type="text/javascript" src="lib/qunit.js"></script>
 		<script type="text/javascript" src="../typo/typo.js"></script>

--- a/tests/index.html
+++ b/tests/index.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="ISO8859-1">
 		<title>Typo.js Test Suites</title>
+		<link rel="stylesheet" href="tests.css" type="text/css" media="screen" />
 	</head>
 	<body>
 		<p>Test suites:</p>

--- a/tests/latin.html
+++ b/tests/latin.html
@@ -3,6 +3,7 @@
 		<meta charset="ISO8859-1">
 		<title>Typo.js Latin Test Suite</title>
 		<link rel="stylesheet" href="lib/qunit.css" type="text/css" media="screen" />
+		<link rel="stylesheet" href="tests.css" type="text/css" media="screen" />
 		<script type="text/javascript" src="lib/jquery-1.9.1.js"></script>
 		<script type="text/javascript" src="lib/qunit.js"></script>
 		<script type="text/javascript" src="../typo/typo.js"></script>

--- a/tests/tests.css
+++ b/tests/tests.css
@@ -1,0 +1,3 @@
+body {
+	width: 500px;
+}


### PR DESCRIPTION
I was unable to run the test suite by following the instructions in the tests/README.md file. Even if I had Typo.js added as a Chrome extension the test pages did not have access to the chrome.extension.getURL API.

I'm unsure how this was meant to work, but I managed to get the tests running by opening them in the extension popup instead. The added CSS is merely to make the popup a bit wider for readability.