### PR TITLE
Add option to load dictionary and affix data asynchronously

### DIFF
--- a/tests/general.js
+++ b/tests/general.js
@@ -18,6 +18,21 @@ function run() {
 		equal(empty_dict._removeAffixComments("\t"), "", "Tabs are treated as whitespace.");
 		equal(empty_dict._removeAffixComments("\n\t \t\n\n"), "", "All whitespace is treated the same.");
 	});
+	
+	test("_readFile can load a file synchronously", function() {
+		var data = empty_dict._readFile(chrome.extension.getURL("../typo/dictionaries/en_US/en_US.dic"));
+		ok(data && data.length > 0);
+	});
+	
+	asyncTest("_readFile can load a file asynchronously", function(assert) {
+		empty_dict._readFile(chrome.extension.getURL("../typo/dictionaries/en_US/en_US.dic"), null, true).then(function(data) {
+			assert.ok(data && data.length > 0);
+			QUnit.start();
+		}, function(err) {
+			QUnit.pushFailure(err);
+			QUnit.start();
+		});
+	});
 }
 
 addEventListener( "load", run, false );

--- a/tests/general.js
+++ b/tests/general.js
@@ -33,6 +33,31 @@ function run() {
 			QUnit.start();
 		});
 	});
+	
+	function checkLoadedDict(dict) {
+		ok(dict);
+		ok(dict.compoundRules.length > 0);
+		ok(dict.replacementTable.length > 0);
+	}
+	
+	test("Dictionary instantiated with preloaded data is setup correctly", function() {
+		var affData = empty_dict._readFile(chrome.extension.getURL("../typo/dictionaries/en_US/en_US.aff"));
+		var wordData = empty_dict._readFile(chrome.extension.getURL("../typo/dictionaries/en_US/en_US.dic"));
+		var dict = new Typo("en_US", affData, wordData);
+		checkLoadedDict(dict);
+	});
+	
+	test("Synchronous load of dictionary data", function() {
+		var dict = new Typo("en_US");
+		checkLoadedDict(dict);
+	});
+	
+	asyncTest("Asynchronous load of dictionary data", function() {
+		var dict = new Typo("en_US", null, null, { asyncLoad: true, loadedCallback: function() {
+			checkLoadedDict(dict);
+			QUnit.start();
+		}});
+	});
 }
 
 addEventListener( "load", run, false );

--- a/tests/general.js
+++ b/tests/general.js
@@ -58,6 +58,17 @@ function run() {
 			QUnit.start();
 		}});
 	});
+	
+	test("Public API throws exception if called before dictionary is loaded", function() {
+		var expected = function(err) {
+			return err === "Dictionary not loaded.";
+		};
+		
+		throws(empty_dict.check, expected);
+		throws(empty_dict.checkExact, expected);
+		throws(empty_dict.hasFlag, expected);
+		throws(empty_dict.check, expected);
+	});
 }
 
 addEventListener( "load", run, false );

--- a/typo/typo.js
+++ b/typo/typo.js
@@ -49,6 +49,7 @@ var Typo = function (dictionary, affData, wordsData, settings) {
 	
 	this.flags = settings.flags || {}; 
 	
+	this.loaded = false;
 	var self = this;
 	
 	if (dictionary) {
@@ -160,6 +161,8 @@ var Typo = function (dictionary, affData, wordsData, settings) {
 
 			self.compoundRules[i] = new RegExp(expressionText, "i");
 		}
+		
+		self.loaded = true;
 		
 		if (settings.asyncLoad && settings.loadedCallback) {
 			settings.loadedCallback();
@@ -574,6 +577,10 @@ Typo.prototype = {
 	 */
 	
 	check : function (aWord) {
+		if (!this.loaded) {
+			throw "Dictionary not loaded.";
+		}
+		
 		// Remove leading and trailing whitespace
 		var trimmedWord = aWord.replace(/^\s\s*/, '').replace(/\s\s*$/, '');
 		
@@ -622,6 +629,10 @@ Typo.prototype = {
 	 */
 	
 	checkExact : function (word) {
+		if (!this.loaded) {
+			throw "Dictionary not loaded.";
+		}
+		
 		var ruleCodes = this.dictionaryTable[word];
 		
 		if (typeof ruleCodes === 'undefined') {
@@ -656,6 +667,10 @@ Typo.prototype = {
 	 */
 	 
 	hasFlag : function (word, flag, wordFlags) {
+		if (!this.loaded) {
+			throw "Dictionary not loaded.";
+		}
+		
 		if (flag in this.flags) {
 			if (typeof wordFlags === 'undefined') {
 				var wordFlags = Array.prototype.concat.apply([], this.dictionaryTable[word]);
@@ -683,6 +698,10 @@ Typo.prototype = {
 	alphabet : "",
 	
 	suggest : function (word, limit) {
+		if (!this.loaded) {
+			throw "Dictionary not loaded.";
+		}
+		
 		if (!limit) limit = 5;
 		
 		if (this.check(word)) return [];


### PR DESCRIPTION
Running Typo.js in a Chrome App is not currently possible since [synchronous XMLHttpRequests are prohibited](https://developer.chrome.com/apps/app_deprecated). The following error is thrown when trying to load a dictionary:

    Error: Failed to execute 'open' on 'XMLHttpRequest': Synchronous requests are disabled for this page.
In order to be able to run Typo.js in a Chrome App (and to improve the user experience overall since synchronous requests block the UI) I implemented an option in the Typo constructor settings to make XMLHttpRequest asynchronously. This is implemented in a backwards-compatible manner. Existing code will still make synchronous calls unless they specify `asyncLoad: true`.

**Notes:**
* Asynchronous loads in Node.js is not implemented although it shouldn't be too problematic to do so. `fs.readSync`is still used regardless of the value of the `asyncLoad` setting.
* In order to write tests for this I had to change the default location of the en_US dictionary in Chrome extensions from `lib/typo/dictionaries/` to `typo/dictionaries/`. As it were, the en_US dictionary was not found out of the box when instantiating Typo without preloaded data. This could break backwards-compatibility for users who have manually placed their dictionaries in the `lib/typo/dictionaries/` folder. If this path is not to be changed I would suggest moving the en_US dictionary files so that Typo can find them by default.

**Further reading regarding synchronous vs. asynchronous XMLHttpRequests:**
https://developers.google.com/web/updates/2012/01/Getting-Rid-of-Synchronous-XHRs
http://blogs.msdn.com/b/wer/archive/2011/08/03/why-you-should-use-xmlhttprequest-asynchronously.aspx