### PR TITLE
Async suggest

### DIFF
--- a/typo/typo.js
+++ b/typo/typo.js
@@ -623,24 +623,7 @@ Typo.prototype = {
 			return true;
 		}
 		
-		// The exact word is not in the dictionary.
-		if (trimmedWord.toUpperCase() === trimmedWord) {
-			// The word was supplied in all uppercase.
-			// Check for a capitalized form of the word.
-			var capitalizedWord = trimmedWord[0] + trimmedWord.substring(1).toLowerCase();
-			
-			if (this.hasFlag(capitalizedWord, "KEEPCASE")) {
-				// Capitalization variants are not allowed for this word.
-				return false;
-			}
-			
-			if (this.checkExact(capitalizedWord)) {
-				return true;
-			}
-		}
-		
 		var lowercaseWord = trimmedWord.toLowerCase();
-		
 		if (lowercaseWord !== trimmedWord) {
 			if (this.hasFlag(lowercaseWord, "KEEPCASE")) {
 				// Capitalization variants are not allowed for this word.
@@ -958,7 +941,7 @@ Typo.prototype = {
 				if (ed2.length===0) ed2=edits1(ed1.pop());
 				next=ed2.pop();
 
-				if (founds.indexOf(next)===-1 && self.check(next)) {
+				if (founds.indexOf(next)===-1 && self.checkExact(next)) {
 					if (progressFunc && progressFunc(next)===false) { 
 						// console.log('suggestions aborted');
 						ed1.length=ed2.length=0; // encourage GC


### PR DESCRIPTION
This PR adds the option of running suggest asynchronously allowing updating the display with results as they come, and stopping a suggestion search midway. Also provides much faster performance and smaller memory use on both synchronous and asynchronous suggests. 

The suggest function can now be called in one of three ways:

suggest(word, limit [=5])
- runs suggest synchronously, same signature as before

suggest(word, limit [=5], doneFunc, progressFunc) where either doneFunc or  progressFunc are defined
- runs suggest asynchronously 
- returns undefined
- doneFunc (if given) will be called (with the sorted results array) once the search is done
- progressFunc (if given) will be called (with the new match) whenever a new match is found in the search
- if progressFunc returns===false the current search will be aborted
- will do the equivalent of sleep(0) every 200ms

suggest()
- abort a current search if running

Other changes:
- improve the ordering of permutations returned from the edits1 function
- closes https://github.com/cfinke/Typo.js/issues/46
- closes https://github.com/cfinke/Typo.js/issues/48
- closes https://github.com/cfinke/Typo.js/issues/49

See a working sample in [plunkr](https://plnkr.co/edit/0y1wCHXx3k3mZaHFOpHT)
