### PR TITLE
Ignore "fs" module in browser builds to support webpack

### DIFF
--- a/typo/package.json
+++ b/typo/package.json
@@ -20,5 +20,8 @@
     "url": "https://github.com/cfinke/Typo.js/issues"
   },
   "homepage": "https://github.com/cfinke/Typo.js#readme",
-  "tonicExample": "var Typo = require('typo-js'); var dictionary = new Typo('en_US'); dictionary.check('mispelled');"
+  "tonicExample": "var Typo = require('typo-js'); var dictionary = new Typo('en_US'); dictionary.check('mispelled');",
+  "browser": {
+    "fs": false
+  }
 }


### PR DESCRIPTION
This fixes https://github.com/cfinke/Typo.js/issues/42.

I just copied https://github.com/pugjs/pug/pull/1644