### PR TITLE
Implement progress callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ To use Typo in a standard web application you need to pass a settings object tha
 var dictionary = new Typo("en_US", false, false, { dictionaryPath: "typo/dictionaries" }),
 ```
 
+To load custom dic and aff files, and you can also provide a callback progress:
+
+```javascript
+var dictionary = new Typo("en_US", affData, wordsData, { progressCallback: function (objectType, i, total) {
+    var pct = parseInt((10000 * i) / _len, 10) / 100;
+    console.log('Processing ' + objectType + ': ' + pct + '%...');
+}}),
+```
+
 If using in node.js, load it like so:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ var dictionary = new Typo("en_US", false, false, { dictionaryPath: "typo/diction
 To load custom dic and aff files, and you can also provide a callback progress:
 
 ```javascript
-var dictionary = new Typo("en_US", affData, wordsData, { progressCallback: function (objectType, i, total) {
-    var pct = parseInt((10000 * i) / _len, 10) / 100;
-    console.log('Processing ' + objectType + ': ' + pct + '%...');
-}}),
+var dictionary = new Typo("en_US", affData, wordsData, {
+    progressCallback: function (objectType, i, total) {
+        var pct = parseInt((10000 * i) / total, 10) / 100;
+        console.log('Processing ' + objectType + ': ' + pct + '%...');
+    }
+}),
 ```
 
 If using in node.js, load it like so:

--- a/tests/general.js
+++ b/tests/general.js
@@ -65,22 +65,6 @@ function run() {
         ok(dicCb);
         ok(affCb);
 	});
-
-	test("Dictionary instatiated with already parsed data", function() {
-        var dicCb = false;
-        var affCb = false;
-		var affData = empty_dict._readFile(chrome.extension.getURL("../typo/dictionaries/en_US/en_US.aff"));
-		var wordData = empty_dict._readFile(chrome.extension.getURL("../typo/dictionaries/en_US/en_US.dic"));
-		var dict = new Typo("en_US", affData, wordData);
-		var rules = dict.rules;
-        var dictionaryTable = dict.dictionaryTable;
-
-        dict = new Typo("en_US", null, null, {
-            rules: rules,
-            dictionaryTable: dictionaryTable
-        });
-        checkLoadedDict(dict);
-	});
 	
 	test("Synchronous load of dictionary data", function() {
 		var dict = new Typo("en_US");

--- a/tests/general.js
+++ b/tests/general.js
@@ -46,6 +46,41 @@ function run() {
 		var dict = new Typo("en_US", affData, wordData);
 		checkLoadedDict(dict);
 	});
+
+	test("Progress callbacks are being called", function() {
+        var dicCb = false;
+        var affCb = false;
+		var affData = empty_dict._readFile(chrome.extension.getURL("../typo/dictionaries/en_US/en_US.aff"));
+		var wordData = empty_dict._readFile(chrome.extension.getURL("../typo/dictionaries/en_US/en_US.dic"));
+		var dict = new Typo("en_US", affData, wordData, {
+            progressCallback: function (obType, i, total) {
+                if (obType === 'dic') {
+                    dicCb = true;
+                } else if (obType === 'aff') {
+                    affCb = true;
+                }
+            }
+        });
+		checkLoadedDict(dict);
+        ok(dicCb);
+        ok(affCb);
+	});
+
+	test("Dictionary instatiated with already parsed data", function() {
+        var dicCb = false;
+        var affCb = false;
+		var affData = empty_dict._readFile(chrome.extension.getURL("../typo/dictionaries/en_US/en_US.aff"));
+		var wordData = empty_dict._readFile(chrome.extension.getURL("../typo/dictionaries/en_US/en_US.dic"));
+		var dict = new Typo("en_US", affData, wordData);
+		var rules = dict.rules;
+        var dictionaryTable = dict.dictionaryTable;
+
+        dict = new Typo("en_US", null, null, {
+            rules: rules,
+            dictionaryTable: dictionaryTable
+        });
+        checkLoadedDict(dict);
+	});
 	
 	test("Synchronous load of dictionary data", function() {
 		var dict = new Typo("en_US");


### PR DESCRIPTION
For large dic files, there is a waiting time with no info about the progress at all.

With this pull request, there is the option to provide a `progressCallback` in `settings`:

```js
var dictionary = new Typo("en_US", affData, wordsData, {
    progressCallback: function (objectType, i, total) {
        var pct = parseInt((10000 * i) / total, 10) / 100;
        console.log('Processing ' + objectType + ': ' + pct + '%...');
    },
}),
```