### PR TITLE
Consistently sort suggestions across javascript engines

### DIFF
--- a/typo/typo.js
+++ b/typo/typo.js
@@ -911,6 +911,7 @@ Typo.prototype = {
 					sorted_corrections.push([ i, weighted_corrections[i] ]);
 				}
 			}
+
 			function sorter(a, b) {
 				var a_val = a[1];
 				var b_val = b[1];

--- a/typo/typo.js
+++ b/typo/typo.js
@@ -913,12 +913,14 @@ Typo.prototype = {
 			}
 			
 			function sorter(a, b) {
-				if (a[1] < b[1]) {
+				var aVal = a[1];
+				var bVal = b[1];
+				if (aVal < bVal) {
 					return -1;
+				} else if (aVal === bVal) {
+					// @todo If a and b are equally weighted, add our own weight based on something like the key locations on this language's default keyboard.
+					return 0
 				}
-				
-				// @todo If a and b are equally weighted, add our own weight based on something like the key locations on this language's default keyboard.
-
 				return 1;
 			}
 			

--- a/typo/typo.js
+++ b/typo/typo.js
@@ -911,17 +911,16 @@ Typo.prototype = {
 					sorted_corrections.push([ i, weighted_corrections[i] ]);
 				}
 			}
-			
 			function sorter(a, b) {
-				var aVal = a[1];
-				var bVal = b[1];
-				if (aVal < bVal) {
+				var a_val = a[1];
+				var b_val = b[1];
+				if (a_val < b_val) {
 					return -1;
-				} else if (aVal === bVal) {
-					// @todo If a and b are equally weighted, add our own weight based on something like the key locations on this language's default keyboard.
-					return 0
+				} else if (a_val > b_val) {
+					return 1;
 				}
-				return 1;
+				// @todo If a and b are equally weighted, add our own weight based on something like the key locations on this language's default keyboard.
+				return b[0].localeCompare(a[0]);
 			}
 			
 			sorted_corrections.sort(sorter).reverse();


### PR DESCRIPTION
In existing code, different javascript engines (versions of node, or different browsers) would return different suggestion orders for suggestions whose scores were tied.

One example word that exhibits this behavior with the built in dictionary is "spellling". When run through https://www.chrisfinke.com/files/typo-demo/
Suggestions in chrome: `spelling, spilling, swelling, smelling, shelling`
Suggestions in firefox: `spelling, spilling, selling, shelling, smelling`


I traced this back to the sorter function, which was returning 1 in the event that the two suggestions had the same score. In the event of a tie, comparators are generally supposed to return 0. Returning 0 is not enough to get the same result on all javascript engines because only recently were browsers forced to sort stable (in the event of a tie, return the items in the same relative order as they were in the original list). So to ensure that the ordering is always the same, I arbitrarily used localeCompare on the words to break ties.

Thanks!