### PR TITLE
Split correctly across newlines in windows

### DIFF
--- a/typo/typo.js
+++ b/typo/typo.js
@@ -290,7 +290,7 @@ Typo.prototype = {
 		// Remove comment lines
 		data = this._removeAffixComments(data);
 		
-		var lines = data.split("\n");
+		var lines = data.split(/\r?\n/);
 		
 		for (i = 0, _len = lines.length; i < _len; i++) {
 			line = lines[i];
@@ -422,7 +422,7 @@ Typo.prototype = {
 	_parseDIC : function (data) {
 		data = this._removeDicComments(data);
 		
-		var lines = data.split("\n");
+		var lines = data.split(/\r?\n/);
 		var dictionaryTable = {};
 		
 		function addWord(word, rules) {


### PR DESCRIPTION
Previously, the line splitting would leave trailing \r characters when the line endings. This was causing us to have different suggestions on windows vs mac.
The specific issue was that on windows the REP entries in the affix file are not used unless they contain exactly 3 entries when split by whitespace, but the extra \r was giving us 4 entries.