### PR TITLE
- correct BUG to check hEllo false...

### DIFF
--- a/typo/typo.js
+++ b/typo/typo.js
@@ -640,7 +640,8 @@ Typo.prototype = {
 			}
 		}
 		
-		var lowercaseWord = trimmedWord.toLowerCase();
+		//var lowercaseWord = trimmedWord.toLowerCase();
+		var lowercaseWord = trimmedWord[0].toLowerCase() + trimmedword.substring(1); 
 		
 		if (lowercaseWord !== trimmedWord) {
 			if (this.hasFlag(lowercaseWord, "KEEPCASE")) {


### PR DESCRIPTION
Hi,

I was wondering while hEllo was checked OK which is not. I found something in the check routines, in which the test word will be completely converted into lower case, which hides the wrong written upper case characters. If I understood the test strategy correctly this PR should fix it or at least gives a hint how to change this!

Cheers,
   Oliver