### PR TITLE
fixed issue preventing spell check for Romance langs

### DIFF
--- a/typo/typo.js
+++ b/typo/typo.js
@@ -540,6 +540,7 @@ Typo.prototype = {
 		else if (this.flags.FLAG === "num") {
 			return textCodes.split(",");
 		}
+		return textCodes.split("");
 	},
 	
 	/**


### PR DESCRIPTION
From Issue #57 

Quote:
> I see this issue is old, but maybe as good a place to comment as any.
> 
> In an attempt to get https://github.com/hackmdio/codimd to show Spanish spelling errors, I could not get https://github.com/wooorm/dictionaries/tree/master/dictionaries/es to work at all.
> 
> I do not know anything at all about parsing the Hunspell SFX lines, but one thing seems sure;
> 
> parseRuleCodes() is broken here as with the first SFX line, we fail badly: https://github.com/wooorm/dictionaries/blob/master/dictionaries/es/index.aff#L112
> 
> ```
>     SFX A r ción/S ar
> ```
> 
> Please take a look at https://github.com/cfinke/Typo.js/blob/master/typo/typo.js#L534 I think this is wrong: we have "FLAG" in this.flags and so we do not in fact match **any** if stanza here and therefore the function returns undefined, resulting in an exception when we try to access .length of undefined in
> 
> https://github.com/cfinke/Typo.js/blob/master/typo/typo.js#L327
> 
> Are you supposed to reset this.flags at some point?
> 
> I tried returning something by default, adding
> 
> ```
> return textCodes.split("");
> ```
> 
> at Line 549 and now the dictionary works.
> 
> @cfinke I hope that may be of some use to you.
> 
> Best regards.

