### PR TITLE
add a logic to parsing some French base words correctly

### DIFF
--- a/typo/typo.js
+++ b/typo/typo.js
@@ -365,6 +365,9 @@ var Typo;
                     continue;
                 }
                 var parts = line.split("/", 2);
+                if (!line.includes("/")) {
+                    parts = line.split(/\s+/);
+                }
                 var word = parts[0];
                 // Now for each affix rule, generate that form of the word.
                 if (parts.length > 1) {


### PR DESCRIPTION
For common Hunspell French dictionaries, the words in .dic files might have morphological flags but no general flags (COMPOUND, etc.), example:
```
comment po:mg po:advint
```
Therefore only parsing by `/` will identify the entire line as the base word and resulting wrong output.

The example case can be found here: https://grammalecte.net/
Go to "Dictionnaires" section and download the "[Dictionnaires 7.0](https://grammalecte.net/dic/hunspell-french-dictionaries-v7.0.zip)"
unzip the downloaded file and the example above can be found in `fr-toutesvariantes.dic` file.