### PR TITLE
change dictionaryTable to Map

### DIFF
--- a/typo/typo.js
+++ b/typo/typo.js
@@ -43,7 +43,7 @@ var Typo;
         settings = settings || {};
         this.dictionary = null;
         this.rules = {};
-        this.dictionaryTable = {};
+        this.dictionaryTable = new Map();
         this.compoundRules = [];
         this.compoundRuleCodes = {};
         this.replacementTable = [];
@@ -338,23 +338,23 @@ var Typo;
          * Parses the words out from the .dic file.
          *
          * @param {string} data The data from the dictionary file.
-         * @returns HashMap The lookup table containing all of the words and
+         * @returns {Map} The lookup table containing all of the words and
          *                 word forms from the dictionary.
          */
         _parseDIC: function (data) {
             data = this._removeDicComments(data);
             var lines = data.split(/\r?\n/);
-            var dictionaryTable = {};
+            var dictionaryTable = new Map();
             function addWord(word, rules) {
                 // Some dictionaries will list the same word multiple times with different rule sets.
-                if (!dictionaryTable.hasOwnProperty(word)) {
-                    dictionaryTable[word] = null;
+                if (!dictionaryTable.has(word)) {
+                    dictionaryTable.set(word, null);
                 }
                 if (rules.length > 0) {
-                    if (dictionaryTable[word] === null) {
-                        dictionaryTable[word] = [];
+                    if (dictionaryTable.get(word) === null) {
+                        dictionaryTable.set(word, []);
                     }
-                    dictionaryTable[word].push(rules);
+                    dictionaryTable.get(word).push(rules);
                 }
             }
             // The first line is the number of words in the dictionary.
@@ -571,7 +571,7 @@ var Typo;
             if (!this.loaded) {
                 throw "Dictionary not loaded.";
             }
-            var ruleCodes = this.dictionaryTable[word];
+            var ruleCodes = this.dictionaryTable.get(word);
             var i, _len;
             if (typeof ruleCodes === 'undefined') {
                 // Check if this might be a compound word.
@@ -588,7 +588,7 @@ var Typo;
                 // means that the word is in the dictionary but has no flags.
                 return true;
             }
-            else if (typeof ruleCodes === 'object') { // this.dictionary['hasOwnProperty'] will be a function.
+            else if (typeof ruleCodes === 'object') { // ruleCodes is an array of rule sets
                 for (i = 0, _len = ruleCodes.length; i < _len; i++) {
                     if (!this.hasFlag(word, "ONLYINCOMPOUND", ruleCodes[i])) {
                         return true;
@@ -610,7 +610,7 @@ var Typo;
             }
             if (flag in this.flags) {
                 if (typeof wordFlags === 'undefined') {
-                    wordFlags = Array.prototype.concat.apply([], this.dictionaryTable[word]);
+                    wordFlags = Array.prototype.concat.apply([], this.dictionaryTable.get(word));
                 }
                 if (wordFlags && wordFlags.indexOf(this.flags[flag]) !== -1) {
                     return true;


### PR DESCRIPTION
When loading large dictionaries (hundreds of thousands of words and word forms), the standard Javascript object can significantly degrade in performance.  Use a Map to make things run more smoothly.